### PR TITLE
Add scatter plot to compare performance and time taken for a subset group

### DIFF
--- a/data/india_pollution.py
+++ b/data/india_pollution.py
@@ -107,6 +107,20 @@ def get_list_of_city_names() -> list:
     return list(data.City.unique())
 
 
+__list_of_coastal_cities = ["Mumbai", "Chennai", "Kolkata", "Visakhapatnam", "Goa", "Pondicherry"]
+
+__list_of_inland_cities = ["Bhopal", "Delhi", "Hyderabad", "Jaipur", "Lucknow", "Patna", "Ranchi", "Srinagar", "Thiruvananthapuram", "Bengaluru"]
+
+def get_list_of_coastal_indian_cities() -> list:
+    """Get a list of coastal cities in India, given the list of cities."""
+    list_of_cities = get_list_of_city_names()
+    coastal_cities = []
+    for city in list_of_cities:
+        if city in __list_of_coastal_cities or city not in __list_of_inland_cities:
+            coastal_cities.append(city)
+    return coastal_cities
+
+
 def india_pollution(
     city_list: list = __city_choice,
     pollution_columns: list = __column_choice,

--- a/data/report.py
+++ b/data/report.py
@@ -11,3 +11,4 @@ class Report:
     prediction: PredictionData
     metrics: dict[str, float]
     filepath: str
+    end_time: float

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
     from plots.comparison_plot import comparison_plot
     from plots.comparison_plot_multi import comparison_plot_multi
     from plots.plot_results_in_heatmap import plot_results_in_heatmap
+    from plots.plot_results_in_scatter_plot import plot_results_in_scatter_plot
 
     import time
     import logging
@@ -56,7 +57,12 @@ if __name__ == "__main__":
     __dataset_row_items: dict[str, list[str]] = {
         # take first 3 from list of cities
         "india_pollution": get_list_of_city_names()[:3],  # ["Gurugram"]
-        "stock_prices": get_a_list_of_growth_stock_tickers(),#get_a_list_of_value_stock_tickers(),
+        "stock_prices": get_a_list_of_growth_stock_tickers()[:2],#get_a_list_of_value_stock_tickers(),
+    }
+
+    __dataset_group_titles: dict[str, str] = {
+        "india_pollution": "Coastal cities in India",
+        "stock_prices": "Value stocks",
     }
 
     __predictors: dict[str, Predict[Dataset, Result]] = {
@@ -215,20 +221,25 @@ if __name__ == "__main__":
                     dataset_name == "stock_prices"
                 ):
                     results_store.append(reports_per_dataset)
+
+                # plot into a scatter plot
+                if dataset_name in ["india_pollution", "stock_prices"]:
+                    plot_results_in_scatter_plot(reports_per_dataset)
+
                 yield reports_per_dataset
 
             if len(results_store) > 1 and number_of_methods > 1:
                 logging.info(
                     f"Plotting results for all {len(results_store)} datasets in {dataset_name} for {number_of_methods} methods..."
                 )
-                plot_results_in_heatmap(results_store)
+                plot_results_in_heatmap(results_store, __dataset_group_titles[dataset_name])
                 logging.info(
                     f"Plotting results for all {len(results_store)} datasets in {dataset_name} - done"
                 )
 
     __datasets = [
-        "india_pollution",
-        #  "stock_prices",
+        # "india_pollution",
+         "stock_prices",
         #"airline_passengers",
         # "list_of_tuples",
         #  "sun_spots",
@@ -238,7 +249,7 @@ if __name__ == "__main__":
     __methods = [
         "AR",
         #  "linear_regression",
-        # "ARIMA",
+        "ARIMA",
         "HoltWinters",
         # "MA",
         # "Prophet",

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     from predictions.Prediction import PredictionData
     from data.load import Load
     from data.report import Report
-    from data.india_pollution import india_pollution, get_list_of_city_names
+    from data.india_pollution import india_pollution, get_list_of_city_names, get_list_of_coastal_indian_cities
     from data.stock_prices import stock_prices, get_a_list_of_value_stock_tickers, get_a_list_of_growth_stock_tickers
     from data.list_of_tuples import list_of_tuples
     from data.airline_passengers import airline_passengers
@@ -113,9 +113,10 @@ if __name__ == "__main__":
         comparison_plot(data.values.loc[training_index, :], prediction)
         datestring_today = time.strftime("%Y-%m-%d")
         filepath = f"reports/full_data/{data.name}_{data.subset_row_name}_{method_name}_{datestring_today}.json.gz"
+        end_time = time.time()
         logging.info(f"Saving report to {filepath}...")
         return Report(
-            start_time, method_name, data, prediction, metrics, filepath=filepath
+            start_time, method_name, data, prediction, metrics, filepath=filepath, end_time=end_time
         )
 
     def __calculate_minimum_length_given_periodicity(periodicity: int) -> int:
@@ -248,10 +249,10 @@ if __name__ == "__main__":
 
     __methods = [
         "AR",
-        #  "linear_regression",
-        "ARIMA",
-        "HoltWinters",
-        # "MA",
+         "linear_regression",
+        # "ARIMA",
+        # "HoltWinters",
+        "MA",
         # "Prophet",
         # "FCNN",
         # "FCNN_embedding",

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     __dataset_row_items: dict[str, list[str]] = {
         # take first 3 from list of cities
         "india_pollution": get_list_of_city_names()[:3],  # ["Gurugram"]
-        "stock_prices": get_a_list_of_growth_stock_tickers()[:2],#get_a_list_of_value_stock_tickers(),
+        "stock_prices": ["DIS"],#get_a_list_of_growth_stock_tickers()[:2],#get_a_list_of_value_stock_tickers(),
     }
 
     __dataset_group_titles: dict[str, str] = {
@@ -223,8 +223,8 @@ if __name__ == "__main__":
                 ):
                     results_store.append(reports_per_dataset)
 
-                # plot into a scatter plot
-                if dataset_name in ["india_pollution", "stock_prices"]:
+                # plot into a scatter plot if at least 3 methods are used
+                if len(methods) > 2:
                     plot_results_in_scatter_plot(reports_per_dataset)
 
                 yield reports_per_dataset

--- a/methods/plot_results_in_heatmap.py
+++ b/methods/plot_results_in_heatmap.py
@@ -18,17 +18,18 @@ from .plot import Figure, Plot
 __chosen_metrics = ["MAE", "RMSE", "R2", "MAPE"]
 
 def plot_results_in_heatmap(
-    compile_results: Callable[[List[List[Report]]],Tuple[Data, str]],
+    compile_results: Callable[[List[List[Report]], str],Tuple[Data, str]],
     plot_heatmap: Callable[[Data, str], Figure],
     save_plot: Callable[[Figure, str, str, str], None],
 ) -> Plot[Data, Prediction, ConfidenceInterval, Title]:
     def draw_plot(
-        list_of_list_of_reports: List[List[Report]]
+        list_of_list_of_reports: List[List[Report]],
+        group_name: str,
     ) -> None:
         print("Plotting results in heatmap")
         results_dataframe, dataset_name = compile_results(list_of_list_of_reports)
         for chosen_metric in __chosen_metrics:
-            figure = plot_heatmap(results_dataframe, chosen_metric)
+            figure = plot_heatmap(results_dataframe, chosen_metric, group_name)
             print(f"Saving {dataset_name} {chosen_metric} heatmap plot")
             save_plot(figure, dataset_name, chosen_metric)
 

--- a/methods/plot_results_in_scatter_plot.py
+++ b/methods/plot_results_in_scatter_plot.py
@@ -1,0 +1,35 @@
+"""Plot a scatterplot  using seaborn showing the accuracy of lots of time series prediction methods
+on lots of different time series"""
+
+from typing import List, Tuple, Optional, Callable, TypeVar, Generator
+
+from data.report import Report
+from methods.plot import Figure
+
+Data = TypeVar("Data", contravariant=True)
+Prediction = TypeVar("Prediction")
+ConfidenceInterval = TypeVar("ConfidenceInterval")
+Title = TypeVar("Title", covariant=True)
+
+
+from .plot import Figure, Plot
+
+
+__chosen_metrics = ["MAE", "RMSE", "R2", "MAPE"]
+
+def plot_results_in_scatter_plot(
+    compile_results_single_dataset: Callable[[List[List[Report]]],Tuple[Data, str]],
+    plot_scatterplot: Callable[[Data, str], Figure],
+    save_plot: Callable[[Figure, str, str, str], None],
+) -> Plot[Data, Prediction, ConfidenceInterval, Title]:
+    def draw_plot(
+        list_of_list_of_reports: List[List[Report]]
+    ) -> None:
+        print("Plotting results in scatter plot")
+        results_dataframe, dataset_name = compile_results_single_dataset(list_of_list_of_reports)
+        for chosen_metric in __chosen_metrics:
+            figure = plot_scatterplot(results_dataframe, chosen_metric)
+            print(f"Saving {dataset_name} {chosen_metric} scatter plot")
+            save_plot(figure, dataset_name, chosen_metric)
+
+    return draw_plot

--- a/methods/plot_results_in_scatter_plot.py
+++ b/methods/plot_results_in_scatter_plot.py
@@ -4,6 +4,7 @@ on lots of different time series"""
 from typing import List, Tuple, Optional, Callable, TypeVar, Generator
 
 from data.report import Report
+import pandas as pd
 from methods.plot import Figure
 
 Data = TypeVar("Data", contravariant=True)
@@ -18,18 +19,17 @@ from .plot import Figure, Plot
 __chosen_metrics = ["MAE", "RMSE", "R2", "MAPE"]
 
 def plot_results_in_scatter_plot(
-    compile_results_single_dataset: Callable[[List[List[Report]]],Tuple[Data, str]],
+    compile_results_single_dataset: Callable[[List[List[Report]]],Data],
     plot_scatterplot: Callable[[Data, str], Figure],
-    save_plot: Callable[[Figure, str, str, str], None],
+    save_plot: Callable[[Figure, pd.DataFrame, str], None],
 ) -> Plot[Data, Prediction, ConfidenceInterval, Title]:
     def draw_plot(
         list_of_list_of_reports: List[List[Report]]
     ) -> None:
         print("Plotting results in scatter plot")
-        results_dataframe, dataset_name = compile_results_single_dataset(list_of_list_of_reports)
+        results_dataframe = compile_results_single_dataset(list_of_list_of_reports)
         for chosen_metric in __chosen_metrics:
             figure = plot_scatterplot(results_dataframe, chosen_metric)
-            print(f"Saving {dataset_name} {chosen_metric} scatter plot")
-            save_plot(figure, dataset_name, chosen_metric)
+            save_plot(figure, results_dataframe, chosen_metric)
 
     return draw_plot

--- a/plots/color_map_by_method.py
+++ b/plots/color_map_by_method.py
@@ -1,0 +1,30 @@
+"""Define a color map for each method."""
+
+from typing import Dict
+
+
+__color_map_by_method_dict = {
+        "AR": "red",
+        "linear_regression": "green",
+        "ARIMA": "orange",
+        "HoltWinters": "gray",
+        "MA": "indigo",
+        "Prophet": "violet",
+        "FCNN": "brown",
+        "FCNN_embedding": "pink",
+        "SARIMA": "darkred",
+        "auto_arima": "darkgreen",
+        "SES": "darkorange",
+        "TsetlinMachine": "lightgray",
+    }
+
+
+
+
+def get_color_map_by_method(method_name:str) -> str:
+    """Return the color for the method, if present."""
+    if method_name in __color_map_by_method_dict:
+        return __color_map_by_method_dict[method_name]
+    else:
+        raise ValueError(f"Method {method_name} not found in color map")
+    

--- a/plots/plot_results_in_heatmap.py
+++ b/plots/plot_results_in_heatmap.py
@@ -46,22 +46,27 @@ def __get_dataset_name(results_dataframe: pd.DataFrame) -> str:
     return results_dataframe["dataset"].unique()[0]
 
 
-def __get_title(results_dataframe: pd.DataFrame, chosen_metric: str) -> str:
+def __get_title(results_dataframe: pd.DataFrame, chosen_metric: str, group_name: str) -> str:
     """Get the title of the plot"""
-    return f"{chosen_metric} results for {__get_dataset_name(results_dataframe)} for {results_dataframe['method'].unique().size} predictive methods on {results_dataframe['subset_row'].unique().size} datasets"
-
+    if group_name is None:
+        return f"{chosen_metric} results for {__get_dataset_name(results_dataframe)} for {results_dataframe['method'].unique().size} predictive methods on {results_dataframe['subset_row'].unique().size} datasets"
+    else:
+        return f"{chosen_metric} results for {group_name} with {results_dataframe['method'].unique().size} predictive methods"
 
 def __plot_heatmap(
-    results_dataframe: pd.DataFrame, chosen_metric: str = "MAE"
+    results_dataframe: pd.DataFrame, chosen_metric: str = "MAE", group_name: Optional[str] = None
 ) -> Figure:
     """Plot the results in a heatmap"""
     logging.info(f"Plotting {chosen_metric} heatmap")
 
-    title = __get_title(results_dataframe, chosen_metric)
+    title = __get_title(results_dataframe, chosen_metric, group_name)
     figure, axis = plt.subplots(figsize=(20, 10))
     axis.set_title(title)
     axis.set_xlabel("Method")
-    axis.set_ylabel("Dataset")
+    if group_name is None:
+        axis.set_ylabel("Dataset")
+    else:
+        axis.set_ylabel(f"Dataset ({group_name})")
     # chose sns colormap that goes from red (high error) to green (low error) without white in the middle
     colormap = sns.diverging_palette(220, 20, as_cmap=True)
 

--- a/plots/plot_results_in_scatter_plot.py
+++ b/plots/plot_results_in_scatter_plot.py
@@ -1,0 +1,97 @@
+"""Plot a scatterplot  using seaborn showing the accuracy (for a given metric) 
+versus time taken (seconds) of lots of time series prediction methods 
+for a single time series"""
+
+
+import os
+import logging
+import datetime
+
+import numpy as np
+
+import seaborn as sns
+import matplotlib.pyplot as plt
+from typing import List, Tuple, Optional
+import pandas as pd
+
+from methods.plot import Figure
+from predictions.Prediction import PredictionData
+
+from data.report import Report
+
+from plots.plot_results_in_heatmap import __get_dataset_name, __get_time_stamp_for_file_name
+from methods.plot_results_in_scatter_plot import plot_results_in_scatter_plot as method
+
+
+
+def __compile_results_single_dataset(list_of_reports: List[Report]) -> Tuple[pd.DataFrame, str]:
+    """Compile the results from a list of lists of reports into a dataframe"""
+    results = []
+    for report in list_of_reports:
+        results.append(
+            {
+                "method": report.method,
+                "dataset": report.dataset.name,
+                "subset_row": report.dataset.subset_row_name,
+                "MAE": report.metrics["mean_absolute_error"],
+                "RMSE": report.metrics["root_mean_squared_error"],
+                "R2": report.metrics["r_squared"],
+                "MAPE": report.metrics["mean_absolute_percentage_error"],
+                "Elapsed (s)": report["Elapsed (s)"],
+            }
+        )
+    results = pd.DataFrame(results)
+    dataset_name = list_of_reports[0].dataset.name
+    return results, dataset_name
+
+
+def __get_title(results_dataframe: pd.DataFrame, chosen_metric: str) -> str:
+    """Get the title of the plot"""
+    return f"{chosen_metric} results for {__get_dataset_name(results_dataframe)} for {results_dataframe['method'].unique().size} predictive methods on {results_dataframe['subset_row'].unique()[0]} dataset"
+
+
+def __plot_scatterplot(
+    results_dataframe: pd.DataFrame, chosen_metric: str = "MAE"
+) -> Figure:
+    """Plot the results in a scatterplot, accuracy metric versus elapsed time"""
+    logging.info(f"Plotting {chosen_metric} scatterplot")
+
+    title = __get_title(results_dataframe, chosen_metric)
+
+    sns.set_theme(style="whitegrid")
+    fig, ax = plt.subplots(figsize=(12, 8))
+    sns.scatterplot(
+        data=results_dataframe,
+        x="Elapsed (s)",
+        y=chosen_metric,
+        hue="method",
+        ax=ax,
+    )
+    ax.set_title(title)
+    ax.set_xlabel("Elapsed (s)")
+    ax.set_ylabel(chosen_metric)
+    return Figure(fig, title)
+
+
+def __get_filename(results_dataframe: pd.DataFrame, chosen_metric: str) -> str:
+    """Get the filename for the plot"""
+    return f"plots/{__get_dataset_name(results_dataframe)}/{__get_time_stamp_for_file_name(results_dataframe)}_{chosen_metric}_scatterplot.png"
+
+
+def __save_plot(figure: Figure, results_dataframe: pd.DataFrame, chosen_metric: str):
+    """Save the scatter plot to a file"""
+    filename = __get_filename(results_dataframe, chosen_metric)
+    logging.info(f"Saving scatter plot to {filename}")
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    figure.save(filename)
+
+    plt.close(figure.fig)
+
+
+plot_results_in_scatter_plot = method(__compile_results_single_dataset, __plot_scatterplot, __save_plot)
+
+
+
+
+
+

--- a/plots/plot_results_in_scatter_plot.py
+++ b/plots/plot_results_in_scatter_plot.py
@@ -9,6 +9,8 @@ import datetime
 
 import numpy as np
 
+from plots.color_map_by_method import __color_map_by_method_dict
+
 import seaborn as sns
 import matplotlib.pyplot as plt
 from typing import List, Tuple, Optional
@@ -61,6 +63,11 @@ def __plot_scatterplot(
 
     title = __get_title(results_dataframe, chosen_metric)
 
+    # use colow map by method dictionary
+    color_map = __color_map_by_method_dict
+
+    # plot the results
+
     sns.set_theme(style="whitegrid")
     fig, ax = plt.subplots(figsize=(12, 8))
     sns.scatterplot(
@@ -69,7 +76,9 @@ def __plot_scatterplot(
         y=chosen_metric,
         hue="method",
         ax=ax,
+        palette=color_map,
     )
+
     ax.set_title(title)
     ax.set_xlabel("Elapsed (s)")
     ax.set_ylabel(chosen_metric)
@@ -83,7 +92,10 @@ def __get_subset_row(results_dataframe: pd.DataFrame) -> str:
 
 def __get_filename(results_dataframe: pd.DataFrame, chosen_metric: str) -> str:
     """Get the filename for the plot"""
-    return f"plots/{__get_dataset_name(results_dataframe)}/{__get_subset_row(results_dataframe)}/{__get_time_stamp_for_file_name()}_{chosen_metric}_scatterplot.png"
+    folder = f"plots/{__get_dataset_name(results_dataframe)}/{__get_subset_row(results_dataframe)}/scatter_plots"
+    if not os.path.exists(folder):
+        os.makedirs(folder, exist_ok=True)
+    return f"{folder}/{chosen_metric}_{__get_time_stamp_for_file_name()}.png"
 
 
 def __save_plot(figure: Figure, results_dataframe: pd.DataFrame, chosen_metric: str):

--- a/predictions/AR.py
+++ b/predictions/AR.py
@@ -31,6 +31,8 @@ import pandas as pd
 
 import logging
 
+from plots.color_map_by_method import get_color_map_by_method
+
 from arch.unitroot import ADF
 from statsmodels.tsa.ar_model import ar_select_order
 from statsmodels.tsa.forecasting.stl import STLForecast
@@ -231,7 +233,7 @@ def __forecast(model: Model, data: Dataset) -> pd.DataFrame:
         number_of_iterations=__calculate_number_of_configurations(),
         confidence_on_mean=True,
         confidence_method="95% confidence interval",
-        color="red",
+        color=get_color_map_by_method("AR"),
         in_sample_prediction=prediction_in_sample.iloc[:, 0],
     )
 

--- a/predictions/ARIMA.py
+++ b/predictions/ARIMA.py
@@ -48,6 +48,8 @@ import pandas as pd
 
 import logging
 
+from plots.color_map_by_method import get_color_map_by_method
+
 from arch.unitroot import ADF
 from statsmodels.tsa.forecasting.stl import STLForecast
 import statsmodels.api as sm
@@ -214,7 +216,7 @@ def __forecast(model: Model, data: Dataset) -> PredictionData:
         number_of_iterations=__calculate_number_of_configurations(),
         confidence_on_mean=True,
         confidence_method="95% confidence interval",
-        color="orange",
+        color=get_color_map_by_method("ARIMA"),
         in_sample_prediction=prediction_in_sample.iloc[:, 0],
     )
 

--- a/predictions/FCNN.py
+++ b/predictions/FCNN.py
@@ -36,6 +36,8 @@ from typing import TypeVar
 from methods.FCNN import fcnn as method
 import pandas as pd
 
+from plots.color_map_by_method import get_color_map_by_method
+
 import tensorflow.keras as keras
 from tensorflow.keras.layers import Dense, Input, Dropout
 
@@ -158,6 +160,7 @@ def __get_predictions(
         title=title,
         plot_folder=f"{data.name}/{data.subset_row_name}/FCNN/",
         plot_file_name=f"{data.subset_column_name}_forecast",
+        color=get_color_map_by_method("FCNN"),
 
     )
 

--- a/predictions/FCNN_embedding.py
+++ b/predictions/FCNN_embedding.py
@@ -30,6 +30,8 @@ from typing import TypeVar
 from methods.FCNN_embedding import fcnn_embedding as method
 import pandas as pd
 
+from plots.color_map_by_method import get_color_map_by_method
+
 import tensorflow as tf
 from keras.optimizers import Adam
 from keras.metrics import MeanAbsoluteError, RootMeanSquaredError
@@ -166,7 +168,7 @@ def __get_predictions(
         title=title,
         plot_folder=f"{data.name}/{data.subset_row_name}/FCNN_embedding/",
         plot_file_name=f"{data.subset_column_name}_forecast",
-
+        color=get_color_map_by_method("FCNN_embedding"),
     )
 
 

--- a/predictions/MA.py
+++ b/predictions/MA.py
@@ -36,6 +36,8 @@ import pandas as pd
 
 import logging
 
+from plots.color_map_by_method import get_color_map_by_method
+
 from arch.unitroot import ADF
 from statsmodels.graphics.tsaplots import plot_acf
 from statsmodels.tsa.forecasting.stl import STLForecast
@@ -230,7 +232,7 @@ def __forecast(model: Model, data: Dataset) -> PredictionData:
         number_of_iterations=__calculate_number_of_configs(__p_values, __d_values, __q_values, __trend_values),
         confidence_on_mean=True,
         confidence_method="95% confidence interval",
-        color="indigo",
+        color=get_color_map_by_method("MA"),
         in_sample_prediction=prediction_in_sample.iloc[:, 0],
     )
 

--- a/predictions/SES.py
+++ b/predictions/SES.py
@@ -92,6 +92,8 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np
 
+from plots.color_map_by_method import get_color_map_by_method
+
 import logging
 
 # turn on logging
@@ -508,7 +510,7 @@ def __predict(
         plot_file_name=f"{data.subset_column_name}_forecast",
         confidence_on_mean=False,
         confidence_method=None,
-        color="darkorange",
+        color=get_color_map_by_method("SES"),
         in_sample_prediction=forecasted_resid_in_sample,
     )
 

--- a/predictions/auto_arima.py
+++ b/predictions/auto_arima.py
@@ -51,6 +51,7 @@ from typing import TypeVar, Generic, List, Tuple, Callable, Dict, Any
 from methods.auto_arima import auto_arima as method
 import pandas as pd
 
+from plots.color_map_by_method import get_color_map_by_method
 
 from multiprocessing import cpu_count
 
@@ -188,7 +189,7 @@ def __forecast_pmdarima(model: Model, data: Dataset) -> pd.DataFrame:
         plot_folder=f"{data.name}/{data.subset_row_name}/auto_arima/",
         plot_file_name=f"{data.subset_column_name}_forecast_{__get_pmdarima_model_order_snake_case(model)}",
         number_of_iterations=model.get_params()["maxiter"],
-        color="darkorange",
+        color=color_map_by_method["auto_arima"],
         in_sample_prediction=prediction_in_sample,
     )
 

--- a/predictions/prophet.py
+++ b/predictions/prophet.py
@@ -35,6 +35,8 @@ from sklearn.metrics import mean_squared_error
 import pandas as pd
 import numpy as np
 
+from plots.color_map_by_method import get_color_map_by_method
+
 import holidays
 import pycountry
 
@@ -437,7 +439,7 @@ def __forecast(model: Model, data: Dataset, number_of_configs: int) -> Predictio
         number_of_iterations=number_of_configs,
         confidence_on_mean=False,
         confidence_method="80% confidence interval by Monte Carlo sampling",
-        color="violet",
+        color=get_color_map_by_method("Prophet"),
         in_sample_prediction=predict_in_sample_df["yhat"],
     )
 

--- a/predictions/tsetlin_machine.py
+++ b/predictions/tsetlin_machine.py
@@ -157,6 +157,8 @@ from sklearn.model_selection import train_test_split
 from data.dataset import Dataset
 from predictions.Prediction import PredictionData
 
+from plots.color_map_by_method import get_color_map_by_method
+
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
@@ -491,7 +493,7 @@ def __get_forecast(
         title=title,
         plot_folder=f"{data.name}/{data.subset_row_name}/tsetlin_machine_regression_model/",
         plot_file_name=f"{data.subset_column_name}_forecast",
-        color="lightgray",
+        color=get_color_map_by_method("Tsetlin Machine Regression"),
     )
 
 


### PR DESCRIPTION
This enables a scatter plot (accuracy versus time taken per model iteration) whenever more than 2 methods are run in one go. Plots are saved under `plots/<dataset_name>/<subset_name>/scatter_plots/`