### PR TITLE
Separate stl decomposition from ses method

### DIFF
--- a/data/seasonal_decompose.py
+++ b/data/seasonal_decompose.py
@@ -12,24 +12,105 @@ the data, and the results are stored in a new dataset.
 
 """
 
-
+import os
 import logging
 import pandas as pd
-from statsmodels.tsa.seasonal import STL
+from statsmodels.tsa.seasonal import STL, DecomposeResult
 from data.dataset import Dataset
 
+import matplotlib.pyplot as plt
+
 from methods.seasonal_decompose import seasonal_decompose as method
+
+PROJECT_FOLDER = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def __get_seasonal_period(data: Dataset) -> int:
+    """Returns the seasonal period"""
+    if data.time_unit == "months":
+        return 12
+    elif data.time_unit == "weeks":
+        return 52
+    elif data.time_unit == "days":
+        return 365
+    elif data.time_unit == "years":
+        return 11
+    else:
+        return 1
+
+
+def __determine_if_seasonal_with_acf(dataset: Dataset) -> bool:
+    """Determines if the data has a seasonal component
+    overriden by the Dataset metadata"""
+    if dataset.seasonality is None:
+
+        if type(dataset.values) is pd.DataFrame:
+            series = pd.Series(
+                dataset.values[dataset.subset_column_name],
+                index=dataset.values.index,
+            )
+        else:
+            series = dataset.values.observed
+        series.dropna(inplace=True)
+
+        return (
+            series.autocorr(
+                lag=__get_seasonal_period(dataset),
+            )
+            > 0.5
+        )
+    else:
+        return dataset.seasonality
+
+
+def __store_plot_of_decomposition_results(
+    data: Dataset, decompose_result: DecomposeResult, type: str = "old"
+) -> None:
+    """Stores a plot of the decomposition results"""
+    logging.info("Storing plot of decomposition results")
+    plt.rcParams.update({"figure.figsize": (10, 9)})
+    fig = decompose_result.plot()
+
+    file_path = f"{PROJECT_FOLDER}/plots/{data.name}/{data.subset_row_name}/STL/{type}_seasonal_decomposition.png"
+
+    if not os.path.exists(os.path.dirname(file_path)):
+        os.makedirs(os.path.dirname(file_path))
+
+    fig.savefig(file_path)
+
 
 def __seasonal_decompose_data(data: Dataset) -> Dataset:
     """Perform STL decomposition on the data."""
     logging.info("Performing STL decomposition")
-    decomposed_data = data.copy()
-    for column in data.values.columns:
-        logging.info(f"Decomposing column {column}")
-        stl = STL(data.values[column], period=12)
-        res = stl.fit()
-        decomposed_data.values[column] = res.resid
-    return decomposed_data
+    seasonal_component_present = __determine_if_seasonal_with_acf(data)
+
+    logging.info(f"Seasonal component present: {seasonal_component_present} for {data.name}")
+
+    if seasonal_component_present:
+        seasonal_period = __get_seasonal_period(data)
+    else:
+        seasonal_period = 1
+
+    logging.info(f"Seasonal period: {seasonal_period}")
+
+    decomposition_stl = STL(
+        data.values[data.subset_column_name],
+        period=seasonal_period,
+        robust=True,
+    ).fit()
+
+    __store_plot_of_decomposition_results(data, decomposition_stl, "STL")
+
+    return Dataset(
+        name=data.name,
+        time_unit=data.time_unit,
+        values=decomposition_stl,
+        number_columns=data.number_columns,
+        subset_row_name=data.subset_row_name,
+        subset_column_name=data.subset_column_name,
+        seasonality=seasonal_component_present,
+    )
+
 
 
 seasonal_decompose = method(__seasonal_decompose_data)

--- a/data/seasonal_decompose.py
+++ b/data/seasonal_decompose.py
@@ -1,0 +1,35 @@
+"""Apply STL decomposition to the data.
+
+Seasonal decomposition is a time series analysis technique that
+decomposes a time series into three components: trend, seasonality,
+and noise. This is useful for identifying trends and seasonality in
+the data, and for removing them to get a better understanding of the
+noise in the data.
+
+This function uses the statsmodels STL decomposition function to
+perform the decomposition. The function is applied to each column of
+the data, and the results are stored in a new dataset.
+
+"""
+
+
+import logging
+import pandas as pd
+from statsmodels.tsa.seasonal import STL
+from data.dataset import Dataset
+
+from methods.seasonal_decompose import seasonal_decompose as method
+
+def __seasonal_decompose_data(data: Dataset) -> Dataset:
+    """Perform STL decomposition on the data."""
+    logging.info("Performing STL decomposition")
+    decomposed_data = data.copy()
+    for column in data.values.columns:
+        logging.info(f"Decomposing column {column}")
+        stl = STL(data.values[column], period=12)
+        res = stl.fit()
+        decomposed_data.values[column] = res.resid
+    return decomposed_data
+
+
+seasonal_decompose = method(__seasonal_decompose_data)

--- a/main.py
+++ b/main.py
@@ -121,12 +121,13 @@ if __name__ == "__main__":
         prediction = __predictors[method_name](data)
         metrics = calculate_metrics(prediction)
 
-
         # if data is a series, then we need to convert it to a dataframe
         if isinstance(data.values, pd.Series):
             data.values = data.values.to_frame()
 
-        training_data = data.values.iloc[: int(len(data.values.index) * (1 - __testset_size)), :]
+        training_data = data.values.iloc[
+            : int(len(data.values.index) * (1 - __testset_size)), :
+        ]
 
         comparison_plot(
             training_data,
@@ -276,17 +277,17 @@ if __name__ == "__main__":
     ]
 
     __methods = [
-        # "AR",
-        #  "linear_regression",
-        # "ARIMA",
-        # "HoltWinters",
-        # "MA",
-        # "Prophet",
+        "AR",
+        "linear_regression",
+        "ARIMA",
+        "HoltWinters",
+        "MA",
+        "Prophet",
         # "FCNN",
         # "FCNN_embedding",
         # "SARIMA",
-        # "auto_arima"
-        #  "SES",
+        "auto_arima",
+        "SES",
         "TsetlinMachineSingle",
         # "TsetlinMachineMulti",
     ]

--- a/methods/decompose.py
+++ b/methods/decompose.py
@@ -3,7 +3,7 @@ from typing import TypeVar, Protocol
 Data = TypeVar("Data", contravariant=True)
 
 
-class Decompose(Protocol[Data, Data]):
+class Decompose(Protocol[Data]):
     def __call__(self, data: Data) -> Data:
         pass
 

--- a/methods/decompose.py
+++ b/methods/decompose.py
@@ -1,0 +1,9 @@
+from typing import TypeVar, Protocol
+
+Data = TypeVar("Data", contravariant=True)
+
+
+class Decompose(Protocol[Data, Data]):
+    def __call__(self, data: Data) -> Data:
+        pass
+

--- a/methods/seasonal_decompose.py
+++ b/methods/seasonal_decompose.py
@@ -13,7 +13,7 @@ from .decompose import Decompose
 
 def seasonal_decompose(
     seasonal_decompose_data: Callable[[Dataset], Dataset],
-) -> Decompose[Dataset, Dataset]:
+) -> Decompose[Dataset]:
     def decompose(
         data: Dataset,
     ) -> Dataset:

--- a/methods/seasonal_decompose.py
+++ b/methods/seasonal_decompose.py
@@ -1,0 +1,23 @@
+"""Perform seasonal decomposition using STL decomposition."""
+
+from typing import Callable, TypeVar
+from data.dataset import Dataset
+from predictions.Prediction import PredictionData
+
+Data = TypeVar("Data", contravariant=True)
+Model = TypeVar("Model")
+Prediction = TypeVar("Prediction")
+
+from .decompose import Decompose
+
+
+def seasonal_decompose(
+    seasonal_decompose_data: Callable[[Dataset], Dataset],
+) -> Decompose[Dataset, Dataset]:
+    def decompose(
+        data: Dataset,
+    ) -> Dataset:
+        decomposed_dataset = seasonal_decompose_data(data)
+        return decomposed_dataset
+
+    return decompose

--- a/methods/tsetlin_machine.py
+++ b/methods/tsetlin_machine.py
@@ -22,7 +22,7 @@ def tsetlin_machine(
     seasonal_decompose_data: Callable[[Dataset], Dataset],
     get_best_model_config: Callable[[Dataset], Dict],
     get_forecast: Callable[[Dataset, dict], Prediction],
-    combine_trend_seasonal_residual: Callable[[Prediction, Prediction, Prediction, Data, Data], Prediction],
+    combine_trend_seasonal_residual: Callable[[Prediction, Prediction, Prediction, Data], Prediction],
 ) -> Predict[Dataset, PredictionData]:
     """
     Return a function that takes a dataset and returns a prediction.
@@ -57,7 +57,7 @@ def tsetlin_machine(
             logging.info(f"Running Tsetlin for stream: {dataset_component.name}")
             params = get_best_model_config(dataset, parallel)   
             list_of_predictions.append(get_forecast(dataset, params))
-        return combine_trend_seasonal_residual(*list_of_predictions, stl_dataset, dataset)
+        return combine_trend_seasonal_residual(*list_of_predictions, stl_dataset)
             
     return predict
 

--- a/methods/tsetlin_machine.py
+++ b/methods/tsetlin_machine.py
@@ -7,6 +7,7 @@ It is a wrapper around the pyTsetlinMachine library.
 """
 
 from typing import Tuple, TypeVar, Callable, Dict
+import pandas as pd
 from data.dataset import Dataset
 from predictions.Prediction import PredictionData
 import logging
@@ -18,6 +19,49 @@ Model = TypeVar("Model")
 Prediction = TypeVar("Prediction")
 
 def tsetlin_machine(
+    seasonal_decompose_data: Callable[[Dataset], Dataset],
+    get_best_model_config: Callable[[Dataset], Dict],
+    get_forecast: Callable[[Dataset, dict], Prediction],
+    combine_trend_seasonal_residual: Callable[[Prediction, Prediction, Prediction, Data, Data], Prediction],
+) -> Predict[Dataset, PredictionData]:
+    """
+    Return a function that takes a dataset and returns a prediction.
+    """
+    def predict(dataset: Dataset, parallel: bool = False) -> PredictionData:
+        """
+        Return a prediction for the given dataset.
+        In this case, the prediction is a combination of the trend, seasonal and residual predictions.
+        
+        """
+        logging.info("Tsetlin Machine Regression")
+        # make a copy of the dataset by iterating through the object
+        dataset = Dataset(**dataset.__dict__)
+
+
+        # decompose the data into trend, seasonal and residual components
+        stl_dataset = seasonal_decompose_data(dataset)
+        trend_dataset_values = stl_dataset.values.trend
+        seasonal_dataset_values = stl_dataset.values.seasonal
+        residual_dataset_values = stl_dataset.values.resid
+
+        # print out the three components in three columns for easy comparison
+        input_data_components = pd.concat(
+        [trend_dataset_values, seasonal_dataset_values, residual_dataset_values], axis=1
+        )
+        input_data_components.columns = ["trend", "seasonal", "residual"]
+        logging.info(f"Three input components:\n{input_data_components.head()}")
+
+        list_of_predictions = []
+        for dataset_component in [trend_dataset_values, seasonal_dataset_values, residual_dataset_values]:
+            dataset.values = dataset_component
+            logging.info(f"Running Tsetlin for stream: {dataset_component.name}")
+            params = get_best_model_config(dataset, parallel)   
+            list_of_predictions.append(get_forecast(dataset, params))
+        return combine_trend_seasonal_residual(*list_of_predictions, stl_dataset, dataset)
+            
+    return predict
+
+def tsetlin_machine_single(
     get_best_model_config: Callable[[Dataset], Dict],
     get_forecast: Callable[[Dataset, dict], Prediction],
 ) -> Predict[Dataset, PredictionData]:

--- a/plots/color_map_by_method.py
+++ b/plots/color_map_by_method.py
@@ -16,6 +16,7 @@ __color_map_by_method_dict = {
         "auto_arima": "darkgreen",
         "SES": "darkorange",
         "TsetlinMachine": "lightgray",
+        "Tsetlin Machine Regression": "lightgray",
     }
 
 

--- a/plots/comparison_plot.py
+++ b/plots/comparison_plot.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import numpy as np
 from typing import Tuple, Optional, List, Dict, Any, Union
@@ -64,7 +65,12 @@ def __full_data_plus_prediction_plot(
     title = prediction.title
     figure, axis = plt.subplots(figsize=(10, 5))
 
-    training_data_series = training_data.iloc[:, 0]
+    logging.debug(f"type of training data: {type(training_data)}")
+    logging.debug(f"size of training data: {training_data.shape}")
+    logging.debug(f"samples of training data: {training_data[:5]}")
+
+    if type(training_data) is pd.DataFrame:
+        training_data_series = training_data.iloc[:, 0]
 
     training_data_series.plot(ax=axis, label="Training data", style=".", c="blue")
 
@@ -132,7 +138,7 @@ def __full_data_plus_prediction_plot(
     axis.set_ylabel(f"{training_data.columns[0]}")
 
     axis.set_ylim(
-        bottom=0, top=1.1 * max(training_data_series.max(), prediction_series.max())
+        bottom=0, top=1.1 * max(training_data_series.max(), prediction_series.max(), ground_truth_series.max())
     )
     axis.legend()
     return figure

--- a/predictions/SES.py
+++ b/predictions/SES.py
@@ -371,7 +371,7 @@ def __fit_model(stl_decomposition_dataset: Dataset) -> Model:
     """Fits the SES model to the data"""
     logging.info(f"Fitting SES model to {stl_decomposition_dataset.name}")
 
-    de_trended_residual = np.abs(stl_decomposition_dataset.values.resid)  # remove negative values
+    de_trended_residual = stl_decomposition_dataset.values.resid  # keep negative values
 
     return SimpleExpSmoothing(endog=de_trended_residual).fit(
         smoothing_level=__alpha,


### PR DESCRIPTION
This is a large modification. Main highlights:

- [ ] Enable Tsetlin machine to run on the three STL decomposed streams: residual, trend and seasonality separately
- [ ] Allow user to select original "single" run Tsetlin approach
- [ ] Move seasonal decomposition from the SES module to its own method, fixes #57 
- [ ] Tidy up on comparison plotting; fixes #132 